### PR TITLE
Autocomplete

### DIFF
--- a/src/components/Signin.vue
+++ b/src/components/Signin.vue
@@ -19,6 +19,7 @@
                 id="email"
                 type="email"
                 v-model="email"
+                autocomplete="username email"
                 required></v-text-field>
             </v-flex>
             <v-flex>
@@ -28,6 +29,7 @@
                 id="password"
                 type="password"
                 v-model="password"
+                autocomplete="current-password"
                 required></v-text-field>
             </v-flex>
             <v-flex class="text-xs-center" mt-5>

--- a/src/components/Signup.vue
+++ b/src/components/Signup.vue
@@ -19,6 +19,7 @@
                 id="email"
                 type="email"
                 v-model="email"
+                autocomplete="username email"
                 required></v-text-field>
             </v-flex>
             <v-flex>
@@ -28,6 +29,7 @@
                 id="password"
                 type="password"
                 v-model="password"
+                autocomplete="new-password"
                 required></v-text-field>
             </v-flex>
             <v-flex>
@@ -38,6 +40,7 @@
                 type="password"
                 required
                 v-model="passwordConfirm"
+                autocomplete="new-password"
                 :rules="[comparePasswords]"
                 ></v-text-field>
             </v-flex>


### PR DESCRIPTION
Running on Chrome gives the following messages:

- [DOM] Input elements should have autocomplete attributes (suggested: "new-password"): (More info: https://goo.gl/9p2vKq) <input name=​"password" id=​"password" required=​"required" type=​"password">​
- :8080/signup:1 [DOM] Input elements should have autocomplete attributes (suggested: "new-password"): (More info: https://goo.gl/9p2vKq) <input name=​"confirmPassword" id=​"confirmPassword" required=​"required" type=​"password">​
- :8080/signin:1 [DOM] Input elements should have autocomplete attributes (suggested: "current-password"): (More info: https://goo.gl/9p2vKq) <input name=​"password" id=​"password" required=​"required" type=​"password">​

This commit addresses those suggestions.